### PR TITLE
Fix Taiwan name (remove "Province of China")

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -363,7 +363,7 @@
         <span class="hljs-attribute">SE</span>: <span class="hljs-string">"Sweden"</span>
         <span class="hljs-attribute">CH</span>: <span class="hljs-string">"Switzerland"</span>
         <span class="hljs-attribute">SY</span>: <span class="hljs-string">"Syrian Arab Republic"</span>
-        <span class="hljs-attribute">TW</span>: <span class="hljs-string">"Taiwan, Province of China"</span>
+        <span class="hljs-attribute">TW</span>: <span class="hljs-string">"Taiwan"</span>
         <span class="hljs-attribute">TJ</span>: <span class="hljs-string">"Tajikistan"</span>
         <span class="hljs-attribute">TZ</span>: <span class="hljs-string">"Tanzania, United Republic of"</span>
         <span class="hljs-attribute">TH</span>: <span class="hljs-string">"Thailand"</span>

--- a/index.coffee
+++ b/index.coffee
@@ -248,7 +248,7 @@ class Iso31661a2
         SE: "Sweden"
         CH: "Switzerland"
         SY: "Syrian Arab Republic"
-        TW: "Taiwan, Province of China"
+        TW: "Taiwan"
         TJ: "Tajikistan"
         TZ: "Tanzania, United Republic of"
         TH: "Thailand"

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@
             SE: "Sweden",
             CH: "Switzerland",
             SY: "Syrian Arab Republic",
-            TW: "Taiwan, Province of China",
+            TW: "Taiwan",
             TJ: "Tajikistan",
             TZ: "Tanzania, United Republic of",
             TH: "Thailand",


### PR DESCRIPTION
In this list, Hong Kong is not even part of China. If that's the case then Taiwan shouldn't also be under province of China.